### PR TITLE
Comments recipe check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-sdk/client-s3": "^3.677.0",
         "@aws-sdk/client-secrets-manager": "^3.677.0",
         "@aws-sdk/lib-dynamodb": "^3.658.1",
-        "@aws-sdk/s3-request-presigner": "^3.677.0",
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -1971,36 +1970,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.677.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.677.0.tgz",
-      "integrity": "sha512-oudJgBX8FPFWiDt/jQ1fW+sJ+XHRMsQ2XXV1aAMCBNsopTBIfn4N8tAymLI3AVJl4UAsxToUITJb5k4NAx2UTw==",
-      "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.677.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-format-url": "3.667.0",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
-      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
-      "dependencies": {
-        "@smithy/types": "^3.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.677.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.677.0.tgz",
@@ -2092,32 +2061,6 @@
         "@aws-sdk/types": "3.654.0",
         "@smithy/types": "^3.4.2",
         "@smithy/util-endpoints": "^2.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.667.0.tgz",
-      "integrity": "sha512-S0D731SnEPnTfbJ/Dldw5dDrOc8uipK6NLXHDs2xIq0t61iwZLMEiN8yWCs2wAZVVJKpldUM1THLaaufU9SSSA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
-      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
-      "dependencies": {
-        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/src/repository/image-dao.js
+++ b/src/repository/image-dao.js
@@ -1,9 +1,4 @@
-const {
-  PutObjectCommand,
-  GetObjectCommand,
-  S3Client
-} = require("@aws-sdk/client-s3");
-const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+const { PutObjectCommand, S3Client } = require("@aws-sdk/client-s3");
 const AWS_REGION = "us-west-1";
 const client = new S3Client({ region: AWS_REGION });
 const { logger } = require("../util/logger");
@@ -13,29 +8,19 @@ async function uploadImageToBucket(Bucket, Key, mime, image) {
     Bucket,
     Key,
     Body: image,
+    ACL: "public-read",
     ContentType: mime
   });
 
   try {
-    const response = await client.send(command);
-    logger.info(`Uploaded image: ${response}`);
-    return response;
+    await client.send(command);
+    const imageUrl = `https://${Bucket}.s3.${AWS_REGION}.amazonaws.com/${Key}`;
+    logger.info(`Uploaded image: ${imageUrl}`);
+    return imageUrl;
   } catch (err) {
     logger.error(err);
     throw new Error(err.message);
   }
 }
 
-async function getPreSignedUrl(Bucket, Key) {
-  try {
-    const command = new GetObjectCommand({ Bucket, Key });
-    const response = await getSignedUrl(client, command, { expiresIn: 3600 });
-    logger.info(`Signed url: ${response}`);
-    return response;
-  } catch (err) {
-    logger.error(err);
-    throw new Error(err.message);
-  }
-}
-
-module.exports = { uploadImageToBucket, getPreSignedUrl };
+module.exports = { uploadImageToBucket };

--- a/src/repository/recipe-dao.js
+++ b/src/repository/recipe-dao.js
@@ -11,7 +11,7 @@ const {
 } = require("@aws-sdk/lib-dynamodb");
 // require("dotenv").config();
 // const AWS_REGION = process.env.AWS_REGION;
-const AWS_REGION = 'us-west-1';
+const AWS_REGION = "us-west-1";
 const { logger } = require("../util/logger");
 
 const client = new DynamoDBClient({ region: AWS_REGION });
@@ -62,7 +62,7 @@ async function insertRecipe(Recipe) {
   try {
     const response = await docClient.send(command);
     logger.info(`Created recipe: ${JSON.stringify(response)}`);
-    return response;
+    return { ...response, uuid: Recipe.uuid };
   } catch (err) {
     logger.error(err);
     throw new Error(err);

--- a/src/service/comment-service.js
+++ b/src/service/comment-service.js
@@ -28,10 +28,10 @@ async function postComment(authorUuid, reqBody) {
         throw new Error("rating is not of type number");
     }
     
-    const recipe = await getItemByUuid(recipeUuid);
-    if (recipe.type !== "recipe") {
-        throw new Error("comment being attached to non-recipe entity");
-    } else {
+    // const recipe = await getItemByUuid(recipeUuid);
+    // if (recipe.type !== "recipe") {
+    //     throw new Error("comment being attached to non-recipe entity");
+    // } else {
         const commentList = await queryCommentsByAuthorUuidRecipeUuid(authorUuid, recipeUuid);
         if(commentList.length > 0){
             throw new Error(`user has already reviewed recipe ${recipeUuid}`);
@@ -48,7 +48,7 @@ async function postComment(authorUuid, reqBody) {
             logger.error(err);
             throw new Error(err);
         }
-    }
+    // }
 }
 
 async function getRecipeComments(recipeUuid) {

--- a/src/service/image-service.js
+++ b/src/service/image-service.js
@@ -7,7 +7,7 @@ async function imageUpload(imageFile) {
     }
 
     const bucket = "recipe-explorer";
-    const objectKey = `images/${Date.now()}_${imageFile.originalname}`;
+    const objectKey = `images/${Date.now()}`;
     const contentType = imageFile.mimetype;
 
     const imageUrl = await uploadImageToBucket(

--- a/src/service/image-service.js
+++ b/src/service/image-service.js
@@ -1,7 +1,4 @@
-const {
-  uploadImageToBucket,
-  getPreSignedUrl
-} = require("../repository/image-dao");
+const { uploadImageToBucket } = require("../repository/image-dao");
 
 async function imageUpload(imageFile) {
   try {
@@ -13,11 +10,14 @@ async function imageUpload(imageFile) {
     const objectKey = `images/${Date.now()}_${imageFile.originalname}`;
     const contentType = imageFile.mimetype;
 
-    await uploadImageToBucket(bucket, objectKey, contentType, imageFile.buffer);
+    const imageUrl = await uploadImageToBucket(
+      bucket,
+      objectKey,
+      contentType,
+      imageFile.buffer
+    );
 
-    const presignedUrl = await getPreSignedUrl(bucket, objectKey);
-
-    return presignedUrl;
+    return imageUrl;
   } catch (err) {
     throw new Error(err.message);
   }


### PR DESCRIPTION
only made changes to 'comment-service'

in postComment, commented out those lines because it prevents a user from being able to leave a comment on a recipe that isn't in our DB, such as recipes we get from MealDB. with it commented out, we're able to post and get comments for MealDB recipes.

a user wont be able to leave a comment on anything other than a recipe on the front end anyways so it should be safe to comment it out.